### PR TITLE
Translation "hors de" -> "depuis"

### DIFF
--- a/legacy/fr.po
+++ b/legacy/fr.po
@@ -4032,7 +4032,7 @@ msgid "other"
 msgstr "autre"
 
 msgid "out of"
-msgstr "hors de"
+msgstr "depuis"
 
 msgid "permissions missing"
 msgstr "permissions manquantes"


### PR DESCRIPTION
Update french translation since it currently means the opposite.
